### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "go"
+run = "go run cmd/cli/main.go"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Run on Repl.it](https://repl.it/badge/github/yauritux/clean-code-architecture)](https://repl.it/github/yauritux/clean-code-architecture)
+
 # clean-code-architecture
 My personal opinion on how the Clean Code Architecture implementation looks like in `Go` within the context of the `Domain Driven Design` (DDD), yet i adopted some terms from the Onion Architecture such as `domain` in order to avoid any misleading interpretations with the `Entity` in `Domain Driven Design`.
 


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).